### PR TITLE
Remove maven repositories at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Planet Documentation provides additional resources to help you integrate LINE Pl
 [Planet Documentation](https://docs.lineplanet.me/)
 
 ## Installation
-To install the latest PlanetKit Android SDK, add the following configuration to your `build.gradle` file.
+To install the latest PlanetKit Android SDK, add the following configuration to your module `build.gradle` file.
 
 ```gradle
-//Module-level
 dependencies {
   implementation 'com.linecorp.planetkit:planetkit:5.3.0'
 }

--- a/README.md
+++ b/README.md
@@ -7,19 +7,9 @@ Planet Documentation provides additional resources to help you integrate LINE Pl
 [Planet Documentation](https://docs.lineplanet.me/)
 
 ## Installation
-To install the latest PlanetKit Android SDK, add the following configuration to your `build.gradle` files.
+To install the latest PlanetKit Android SDK, add the following configuration to your `build.gradle` file.
 
 ```gradle
-//Project-level
-allprojects {
-  repositories {
-    maven {
-        url 'https://maven.pkg.github.com/line/planet-kit-android/'
-        allowInsecureProtocol true
-    }
-  }
-}
-
 //Module-level
 dependencies {
   implementation 'com.linecorp.planetkit:planetkit:5.3.0'


### PR DESCRIPTION
Remove maven repositories at README.md
The repository uses 'Maven Central', so there is no need for any further configuration.